### PR TITLE
Zm est read time

### DIFF
--- a/SQLQuery1.sql
+++ b/SQLQuery1.sql
@@ -1,5 +1,4 @@
 ﻿
 
 SELECT *
-FROM Post
-WHERE Id = 5
+

--- a/SQLQuery1.sql
+++ b/SQLQuery1.sql
@@ -2,5 +2,5 @@
                             SET [Name] = 'Family'
                             WHERE Id = 4
 
-SELECT * FROM post 
+SELECT * FROM Comment
                        

--- a/SQLQuery1.sql
+++ b/SQLQuery1.sql
@@ -1,6 +1,5 @@
-﻿UPDATE post
-                            SET [Name] = 'Family'
-                            WHERE Id = 4
+﻿
 
-SELECT * FROM Comment
-                       
+SELECT *
+FROM Post
+WHERE Id = 5

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -36,16 +36,19 @@ namespace TabloidMVC.Models
 
         public int EstimatedReadTime
         {
-            get
-            {
-                int roundedTime;
-                    
+            get {
+                    int roundedTime = 0;
+
+                if (Content != null)
+                { 
+
                     int wordCount = Content.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
-                    double exactTime = wordCount/200;
+                    double exactTime = wordCount/250;
                     roundedTime = (int)Math.Ceiling(exactTime);
-                
-                return roundedTime;
-            }
+                }
+                    return roundedTime;
+                }
+            
         }
     }
 }

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -41,17 +41,15 @@ namespace TabloidMVC.Models
 
                 if (Content != null)
                 { 
-
                     int wordCount = Content.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
-                    double exactTime = wordCount/265;
+                    double exactTime = wordCount/250;
                     roundedTime = (int)Math.Ceiling(exactTime);
                         if (roundedTime == 0)
                     {
                         roundedTime = 1;
                     }
                 }
-                    
-                    
+               
                     return roundedTime;
                 }
             

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -34,23 +34,36 @@ namespace TabloidMVC.Models
         [DisplayName("Author")]
         public int UserProfileId { get; set; }
         public UserProfile UserProfile { get; set; }
-
+        // Tacking on an estimated reading time to be displayed with each post
         public int EstimatedReadTime
         {
+                // getting, but not setting here
             get {
+                        // you want to return an est readtime, so start the counter at 0
                     int roundedTime = 0;
 
+                    //if the Content field is filled out - do the following
                 if (Content != null)
                 { 
-                    int wordCount = Content.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
+                        // Take the Content field input as a string and use the Split method to pass in an 
+                        // empty string to represent a whitespace character (' ') as the parameter.
+                        // This will create a new string for every word by slitting it on the whitespace.
+                        // Now use .Length to count the number of whitspace occurances. 
+                        // and store that number in the variable int wordCount.
+                    int wordCount = Content.Split(' ').Length;
+                        // Now get the readtime by dividing the wordcount by 250(words per minute)
+                        // and store that number in the variable double exactTime
                     double exactTime = wordCount/250;
+                        // Next, take the exactTime and use the Math.Ceiling method it.
+                        // This will round up to the next integer and store it in the roundedTime variable
                     roundedTime = (int)Math.Ceiling(exactTime);
+                            // if roundedTime is less than 1 minute, then round it up to 1 minute readtime
                         if (roundedTime == 0)
                     {
                         roundedTime = 1;
                     }
                 }
-               
+                        // return the rounded up integer to be displayed with the post details on the browser
                     return roundedTime;
                 }
             

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -15,6 +15,7 @@ namespace TabloidMVC.Models
         public string Content { get; set; }
 
         [DisplayName("Header Image URL")]
+        [Url]
         public string ImageLocation { get; set; }
 
         public DateTime CreateDateTime { get; set; }

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -43,9 +43,15 @@ namespace TabloidMVC.Models
                 { 
 
                     int wordCount = Content.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
-                    double exactTime = wordCount/250;
+                    double exactTime = wordCount/265;
                     roundedTime = (int)Math.Ceiling(exactTime);
+                        if (roundedTime == 0)
+                    {
+                        roundedTime = 1;
+                    }
                 }
+                    
+                    
                     return roundedTime;
                 }
             

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -33,5 +33,21 @@ namespace TabloidMVC.Models
         [DisplayName("Author")]
         public int UserProfileId { get; set; }
         public UserProfile UserProfile { get; set; }
+
+        public int EstimatedReadTime
+        {
+            get
+            {
+                int roundedTime;
+                    
+                    int wordCount = Content.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
+                    double exactTime = wordCount/200;
+                    roundedTime = (int)Math.Ceiling(exactTime);
+                
+                return roundedTime;
+            }
+        }
     }
 }
+
+

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -38,7 +38,7 @@ namespace TabloidMVC.Models
         {
             get
             {
-                int roundedTime;
+                int roundedTime = 1;
                     
                     int wordCount = Content.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
                     double exactTime = wordCount/200;

--- a/TabloidMVC/Repositories/IPostRepository.cs
+++ b/TabloidMVC/Repositories/IPostRepository.cs
@@ -11,7 +11,6 @@ namespace TabloidMVC.Repositories
         Post GetPublishedPostById(int id);
         Post GetUserPostById(int id, int userProfileId);
         void UpdatePost(Post post);
-       
         void DeletePost(int postId);
     }
 }

--- a/TabloidMVC/Repositories/PostRepository.cs
+++ b/TabloidMVC/Repositories/PostRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Reflection.PortableExecutable;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
@@ -42,7 +43,7 @@ namespace TabloidMVC.Repositories
                     {
                         posts.Add(NewPostFromReader(reader));
                     }
-                    
+
                     reader.Close();
 
                     return posts;
@@ -237,16 +238,14 @@ namespace TabloidMVC.Repositories
             }
         }
 
-
-
         public void UpdatePost(Post post)
-            {
+        {
             using (var conn = Connection)
             {
                 conn.Open();
                 using (var cmd = conn.CreateCommand())
                 {
-                        cmd.CommandText = @"
+                    cmd.CommandText = @"
                             UPDATE Post
                             SET 
                                 Title = @title, 
@@ -260,17 +259,17 @@ namespace TabloidMVC.Repositories
                             WHERE Id = @id";
                     cmd.Parameters.AddWithValue("@id", post.Id);
                     cmd.Parameters.AddWithValue("@title", post.Title);
-                        cmd.Parameters.AddWithValue("@content", post.Content);
-                        cmd.Parameters.AddWithValue("@imageLocation", DbUtils.ValueOrDBNull(post.ImageLocation));
-                        cmd.Parameters.AddWithValue("@createDateTime", post.CreateDateTime);
-                        cmd.Parameters.AddWithValue("@publishDateTime", DbUtils.ValueOrDBNull(post.PublishDateTime));
-                        cmd.Parameters.AddWithValue("@isApproved", post.IsApproved);
-                        cmd.Parameters.AddWithValue("@categoryId", post.CategoryId);
-                        cmd.Parameters.AddWithValue("@userProfileId", post.UserProfileId);
-                        cmd.ExecuteNonQuery();
-                    }
+                    cmd.Parameters.AddWithValue("@content", post.Content);
+                    cmd.Parameters.AddWithValue("@imageLocation", DbUtils.ValueOrDBNull(post.ImageLocation));
+                    cmd.Parameters.AddWithValue("@createDateTime", post.CreateDateTime);
+                    cmd.Parameters.AddWithValue("@publishDateTime", DbUtils.ValueOrDBNull(post.PublishDateTime));
+                    cmd.Parameters.AddWithValue("@isApproved", post.IsApproved);
+                    cmd.Parameters.AddWithValue("@categoryId", post.CategoryId);
+                    cmd.Parameters.AddWithValue("@userProfileId", post.UserProfileId);
+                    cmd.ExecuteNonQuery();
                 }
             }
+        }
 
         public void DeletePost(int postId)
         {
@@ -290,38 +289,5 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
-
-        public void CountWordsInArticle()
-        {
-            string str;
-            int i, words, l;
-
-            Console.Write("\n\nCount the total number of words in a string :\n");
-            Console.Write("------------------------------------------------------\n");
-            Console.Write("Input the string : ");
-            str = Console.ReadLine();
-
-            l = 0;
-            words = 1;
-
-            /* loop till end of string */
-            while (l <= str.Length - 1)
-            {
-                /* check whether the current character is white space or new line or tab character*/
-                if (str[l] == ' ' || str[l] == '\n' || str[l] == '\t')
-                {
-                    words++;
-                }
-
-                l++;
-            }
-
-            Console.Write("Total number of words is : {0}\n", words);
-        }
     }
 }
-
-
-
-                    
-

--- a/TabloidMVC/Repositories/PostRepository.cs
+++ b/TabloidMVC/Repositories/PostRepository.cs
@@ -291,8 +291,37 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
+
+        public void CountWordsInArticle()
+        {
+            string str;
+            int i, words, l;
+
+            Console.Write("\n\nCount the total number of words in a string :\n");
+            Console.Write("------------------------------------------------------\n");
+            Console.Write("Input the string : ");
+            str = Console.ReadLine();
+
+            l = 0;
+            words = 1;
+
+            /* loop till end of string */
+            while (l <= str.Length - 1)
+            {
+                /* check whether the current character is white space or new line or tab character*/
+                if (str[l] == ' ' || str[l] == '\n' || str[l] == '\t')
+                {
+                    words++;
+                }
+
+                l++;
+            }
+
+            Console.Write("Total number of words is : {0}\n", words);
+        }
     }
-    }
+}
+
 
 
                     

--- a/TabloidMVC/Utils/DbUtils.cs
+++ b/TabloidMVC/Utils/DbUtils.cs
@@ -28,6 +28,34 @@ namespace TabloidMVC.Utils
         public static object ValueOrDBNull(object value)
         {
             return value ?? DBNull.Value;
-        } 
+        }
+
+        public static void CountWordsInArticle(string column)
+        {
+            string str;
+            int i, words, l;
+
+            Console.Write("\n\nCount the total number of words in a string :\n");
+            Console.Write("------------------------------------------------------\n");
+            Console.Write("Input the string : ");
+            str = Console.ReadLine();
+
+            l = 0;
+            words = 1;
+
+            /* loop till end of string */
+            while (l <= str.Length - 1)
+            {
+                /* check whether the current character is white space or new line or tab character*/
+                if (str[l] == ' ' || str[l] == '\n' || str[l] == '\t')
+                {
+                    words++;
+                }
+
+                l++;
+            }
+
+            Console.Write("Total number of words is : {0}\n", words);
+        }
     }
 }

--- a/TabloidMVC/Utils/DbUtils.cs
+++ b/TabloidMVC/Utils/DbUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Data.SqlClient;
+using TabloidMVC.Models;
 
 namespace TabloidMVC.Utils
 {
@@ -30,32 +31,6 @@ namespace TabloidMVC.Utils
             return value ?? DBNull.Value;
         }
 
-        public static void CountWordsInArticle(string column)
-        {
-            string str;
-            int i, words, l;
 
-            Console.Write("\n\nCount the total number of words in a string :\n");
-            Console.Write("------------------------------------------------------\n");
-            Console.Write("Input the string : ");
-            str = Console.ReadLine();
-
-            l = 0;
-            words = 1;
-
-            /* loop till end of string */
-            while (l <= str.Length - 1)
-            {
-                /* check whether the current character is white space or new line or tab character*/
-                if (str[l] == ' ' || str[l] == '\n' || str[l] == '\t')
-                {
-                    words++;
-                }
-
-                l++;
-            }
-
-            Console.Write("Total number of words is : {0}\n", words);
-        }
     }
 }

--- a/TabloidMVC/Views/Post/Delete.cshtml
+++ b/TabloidMVC/Views/Post/Delete.cshtml
@@ -4,28 +4,7 @@
     ViewData["Title"] = "Delete";
 }
 
-<<<<<<< HEAD
-<div class="container pt-5">
-    <div class="post">
-        <section class="px-3">
-            <div class="row justify-content-between">
-                <h1 class="text-secondary">Are you sure you want to delete this post?</h1>
-            </div>
-            <div class="row justify-content-between">
-                <form asp-action="Delete">
-                    <input type="submit" value="Delete" class="btn btn-outline-primary mx-1" />
-                    <a class="btn btn-outline-primary mx-1" asp-action="Details" asp-route-id="@Model.Id">Back</a>
-                </form>
-            </div>
-            <br />
-            <div class="row justify-content-between">
-                <h1 class="text-secondary">@Model.Title</h1>
-                @*<h1 class="text-black-50">@Model.Category.Name</h1*@>
-            </div>
-            <div class="row justify-content-between">
-                <p class="text-secondary">Written by @Model.UserProfile.DisplayName</p>
-                <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
-=======
+
 <h1>Delete</h1>
 
 <h1 class="text-secondary">Are you sure you want to delete this post?</h1>

--- a/TabloidMVC/Views/Post/Delete.cshtml
+++ b/TabloidMVC/Views/Post/Delete.cshtml
@@ -19,7 +19,7 @@
             <br />
             <div class="row justify-content-between">
                 <h1 class="text-secondary">@Model.Title</h1>
-                <h1 class="text-black-50">@Model.Category.Name</h1>
+                @*<h1 class="text-black-50">@Model.Category.Name</h1*@>
             </div>
             <div class="row justify-content-between">
                 <p class="text-secondary">Written by @Model.UserProfile.DisplayName</p>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -17,16 +17,18 @@
                 <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
             </div>
             <div class="row justify-content-between">
-                <p>
+                <div>
+                        @*if the readtime is 1 minute, display "1 min"
+                        otherwise, display "[x] mins"*@
                     @if (Model.EstimatedReadTime == 1)
                     {
-                    <p class="text-black-50">Estimated Reading Time: @Model.EstimatedReadTime min</p>
-                }
-                else
-                {
-                    <p class="text-black-50">Estimated Reading Time: @Model.EstimatedReadTime mins</p>
-                }
-                </p>
+                        <p class="text-black-50">Estimated Reading Time: @Model.EstimatedReadTime min</p>
+                    }
+                    else
+                    {
+                        <p class="text-black-50">Estimated Reading Time: @Model.EstimatedReadTime mins</p>
+                    }
+                </div>
                 <div>
                     <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Edit">
                         <i class="fas fa-pencil-alt"></i>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -45,7 +45,7 @@
                 </section>
             }
 
-            <p class="text-secondary">Words in atricle = @Html.DisplayFor(model => model.Content))</p>
+            <p class="text-secondary">@Html.DisplayFor(model => model.Content))</p>
 
             
         </section>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -16,7 +16,7 @@
 
                 <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
             </div>
-            <div class="row justify-content-between">
+            <div class="row float-left">
                 <p>
                     @if (Model.EstimatedReadTime == 1)
                     {

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -12,42 +12,45 @@
                 <h1 class="text-black-50">@Model.Category.Name</h1>
             </div>
             <div class="row justify-content-between">
-
-
                 <p class="text-secondary">Written by @Model.UserProfile.DisplayName</p>
 
                 <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
-
-                <p class="text-secondary">Words in atricle = @Html.DisplayFor(model => model.Content))</p>
             </div>
-
-            @if (Model.EstimatedReadTime == 1)
-            {
-                <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime min</p>
-            }
-            else
-            {
-                <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime mins</p>
-            }
-
-            <div class="row">
-                <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Edit">
-                    <i class="fas fa-pencil-alt"></i>
-                </a>
-                <a asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Delete">
-                    <i class="fas fa-trash"></i>
-                </a>
+            <div class="row justify-content-between">
+                <p>
+                    @if (Model.EstimatedReadTime == 1)
+                    {
+                    <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime min</p>
+                }
+                else
+                {
+                    <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime mins</p>
+                }
+                </p>
+                <div>
+                    <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                        <i class="fas fa-pencil-alt"></i>
+                    </a>
+                    <a asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                        <i class="fas fa-trash"></i>
+                    </a>
+                </div>
             </div>
+            @if (!string.IsNullOrWhiteSpace(Model.ImageLocation))
+            {
+                <section class="row justify-content-center">
+                    <div>
+                        <img src="@Model.ImageLocation" />
+                    </div>
+                </section>
+            }
+
+            <p class="text-secondary">Words in atricle = @Html.DisplayFor(model => model.Content))</p>
+
+            
         </section>
         <hr />
-        @if (!string.IsNullOrWhiteSpace(Model.ImageLocation))
-        {
-            <section class="row justify-content-center">
-                <div>
-                    <img src="@Model.ImageLocation" />
-                </div>
-            </section>
-        }
+        
         <section class="row post__content">
             <p class="col-sm-12 mt-5">@Html.DisplayFor(model => model.Content)</p>
         </section>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -16,15 +16,15 @@
 
                 <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
             </div>
-            <div class="row float-left">
+            <div class="row justify-content-between">
                 <p>
                     @if (Model.EstimatedReadTime == 1)
                     {
-                    <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime min</p>
+                    <p class="text-black-50">Estimated Reading Time: @Model.EstimatedReadTime min</p>
                 }
                 else
                 {
-                    <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime mins</p>
+                    <p class="text-black-50">Estimated Reading Time: @Model.EstimatedReadTime mins</p>
                 }
                 </p>
                 <div>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -21,13 +21,13 @@
                 @*<p class="text-secondary">Words in atricle = @Html.DisplayFor(Post.CountWordsInArticle(model => model.Content))</p>*@
             </div>
 
-            @*@if (Model.estimatedReadTime() == 1)
+            @*@if (Model.EstimatedReadTime() == 1)
         {
-            <p class="text-black-50">Estimated Read Time: @Model.estimatedReadTime() min</p>
+            <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime() min</p>
         }
         else
         {
-            <p class="text-black-50">Estimated Read Time: @Model.estimatedReadTime() mins</p>
+            <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime() mins</p>
         }*@
 
             <div class="row">

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -12,9 +12,24 @@
                 <h1 class="text-black-50">@Model.Category.Name</h1>
             </div>
             <div class="row justify-content-between">
+
+
                 <p class="text-secondary">Written by @Model.UserProfile.DisplayName</p>
+
                 <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
+
+                @*<p class="text-secondary">Words in atricle = @Html.DisplayFor(Post.CountWordsInArticle(model => model.Content))</p>*@
             </div>
+
+            @*@if (Model.estimatedReadTime() == 1)
+        {
+            <p class="text-black-50">Estimated Read Time: @Model.estimatedReadTime() min</p>
+        }
+        else
+        {
+            <p class="text-black-50">Estimated Read Time: @Model.estimatedReadTime() mins</p>
+        }*@
+
             <div class="row">
                 <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Edit">
                     <i class="fas fa-pencil-alt"></i>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -18,17 +18,17 @@
 
                 <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
 
-                @*<p class="text-secondary">Words in atricle = @Html.DisplayFor(Post.CountWordsInArticle(model => model.Content))</p>*@
+                <p class="text-secondary">Words in atricle = @Html.DisplayFor(model => model.Content))</p>
             </div>
 
-            @*@if (Model.EstimatedReadTime() == 1)
-        {
-            <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime() min</p>
-        }
-        else
-        {
-            <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime() mins</p>
-        }*@
+            @if (Model.EstimatedReadTime == 1)
+            {
+                <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime min</p>
+            }
+            else
+            {
+                <p class="text-black-50">Estimated Read Time: @Model.EstimatedReadTime mins</p>
+            }
 
             <div class="row">
                 <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Edit">

--- a/TabloidMVC/Views/Tag/Index.cshtml
+++ b/TabloidMVC/Views/Tag/Index.cshtml
@@ -8,7 +8,7 @@
 
 <p>
     @*<a asp-action="Create">Create New</a>*@
-    <a type="submit" asp-action="Create" class="btn btn-primary"> Create A New Category </a>
+    <a type="submit" asp-action="Create" class="btn btn-primary"> Create A New Tag </a>
 </p>
 <table class="table">
     <thead>


### PR DESCRIPTION
# Description
Developed a feature that will display the Estimated Reading Time for a given Post along with that post's details. 

# Ticket Reference
> [#23 - View Post Comments](https://github.com/nss-day-cohort-41/tabloidmvc-oysters-rockefeller-rose/issues/23)

## Type of change

- [x] **New feature** (non-breaking change which adds functionality)

# Testing Instructions
- Run both files in the SQL folder.
- Have at least 2 posts created via SQL
- Start program with ISS Express
- Go to localhost:5001 in your browser.
- Login with "admin@example.com"
- Navigate to the Posts link in the navbar.
- Click the eyeball button on the first Post, which should have a title "C# is the Best Language"
- Near the top of the page on the left side should be the words "Estimated Reading Time:" followed by the number of minutes it will take to read the content.
- Visually confirm the Estimated Reading Time on as many posts as you like.
- Edit the content field to lengthen or shorten the number of words. And then watch to see if the Estimated Reading Time changes.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works